### PR TITLE
Fix wallet sync filter logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,9 @@ async function fetchHoldings(walletToSync?: string): Promise<void> {
     let wallets = SUBSCRIBE_WALLETS;
     if (walletToSync) {
       const filteredWallet = wallets.filter((w) => w.address === walletToSync);
-      if (filteredWallet) wallets = filteredWallet;
+      if (filteredWallet.length > 0) {
+        wallets = filteredWallet;
+      }
     }
 
     for (const wallet of wallets) {


### PR DESCRIPTION
## Summary
- avoid clearing wallet list when wallet to sync isn't found

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bd54110f4832bbc32dbf7099f7397