### PR TITLE
Fix typo in response types

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import sqlite3 from "sqlite3";
 import { open } from "sqlite";
 import { config } from "./config";
-import { DuplicateOwnerMintRecord, SplTokenHolding, SplTokenStoreReponse } from "./types";
+import { DuplicateOwnerMintRecord, SplTokenHolding, SplTokenStoreResponse } from "./types";
 
 // Holdings
 export async function createHoldingsTable(database: any): Promise<boolean> {
@@ -23,7 +23,7 @@ export async function createHoldingsTable(database: any): Promise<boolean> {
     return false;
   }
 }
-export async function updateHoldings(holdings: SplTokenHolding[], walletAddress: string): Promise<SplTokenStoreReponse> {
+export async function updateHoldings(holdings: SplTokenHolding[], walletAddress: string): Promise<SplTokenStoreResponse> {
   try {
     const db = await open({
       filename: config.db.db_name_tracker_transfers,
@@ -74,7 +74,7 @@ export async function updateHoldings(holdings: SplTokenHolding[], walletAddress:
     await db.close();
 
     // Return data
-    const returnData: SplTokenStoreReponse = {
+    const returnData: SplTokenStoreResponse = {
       added: addedTokens,
       removed: removedTokens,
       msg: "success",
@@ -84,7 +84,7 @@ export async function updateHoldings(holdings: SplTokenHolding[], walletAddress:
     return returnData;
   } catch (error: any) {
     // Return data
-    const returnData: SplTokenStoreReponse = {
+    const returnData: SplTokenStoreResponse = {
       added: [],
       removed: [],
       msg: "Error: " + error.message,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ import WebSocket from "ws"; // Node.js websocket library
 import * as dotenv from "dotenv";
 import { getDoubleHoldings, getWalletTokenHoldings } from "./walletTracker";
 import {
-  getAccountInfoStreamReponseWithConfirmation,
+  getAccountInfoStreamResponseWithConfirmation,
   GetWalletTokenHoldingsResponse,
   MintWithOwnersResponse,
   SplTokenHolding,
-  SplTokenStoreReponse,
+  SplTokenStoreResponse,
 } from "./types";
 import { config } from "./config";
 import { clearHoldingsTable, updateHoldings } from "./db";
@@ -129,7 +129,7 @@ async function fetchHoldings(walletToSync?: string): Promise<void> {
       // Wallet1 🀄️ (KEN7...WdYT) holds 265 SPL-Tokens
 
       // Store holdings in local database
-      const stored: SplTokenStoreReponse = await updateHoldings(tokenHoldingsData, publicKey.toString());
+      const stored: SplTokenStoreResponse = await updateHoldings(tokenHoldingsData, publicKey.toString());
       if (!stored.success) {
         saveLogTo(actionsLogs, `⛔ Error while storing transfers for wallet ${walletName}. Reason: ${stored.msg}`);
         continue;
@@ -268,7 +268,7 @@ async function accountSubscribeStream(): Promise<void> {
   ws.on("message", async (data: WebSocket.Data) => {
     try {
       const jsonString = data.toString();
-      const accountInfo: getAccountInfoStreamReponseWithConfirmation = JSON.parse(jsonString);
+      const accountInfo: getAccountInfoStreamResponseWithConfirmation = JSON.parse(jsonString);
 
       // Handle subscription confirmation
       if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,13 +25,13 @@ export interface GetWalletTokenHoldingsResponse {
   success: boolean;
   msg: string;
 }
-export interface SplTokenStoreReponse {
+export interface SplTokenStoreResponse {
   success: boolean;
   added: SplTokenHolding[];
   removed: string[];
   msg: string;
 }
-export interface getAccountInfoStreamReponse {
+export interface getAccountInfoStreamResponse {
   jsonrpc: string;
   method: "accountNotification";
   params: {
@@ -63,7 +63,7 @@ export interface getAccountInfoStreamReponse {
     subscription: number;
   };
 }
-export interface getAccountInfoStreamReponseWithConfirmation extends getAccountInfoStreamReponse {
+export interface getAccountInfoStreamResponseWithConfirmation extends getAccountInfoStreamResponse {
   id?: string; // Confirmation ID
   result?: null; // Confirmation result
 }


### PR DESCRIPTION
## Summary
- rename `SplTokenStoreReponse` -> `SplTokenStoreResponse`
- rename `getAccountInfoStreamReponse` -> `getAccountInfoStreamResponse`
- update references in database and main index
- ensure TypeScript build passes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686c2d89f598832ba75f067614709ed6